### PR TITLE
refactor: notifier lifecycle, dead code, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Assigning a `tag.*` entity to a chore enables NFC tap-to-complete. When the tag 
 
 If multiple chores share the same tag, only the chore whose completion window matches the scan time is completed.
 
-When a chore is created with a `trigger_entity`, the tag's last-scanned timestamp is used to seed `last_completed` — this allows migration from existing tag-based systems without losing the most recent completion.
+When a chore is created with a `trigger_entity`, the tag's last-scanned timestamp is used to seed `last_completed` — this allows migration from existing tag-based systems without losing the most recent completion. Note that the chore's initial status will reflect the seeded `last_completed` (typically `completed` for a recently-scanned tag), not the standard never-completed `pending`.
 
 ## Services
 

--- a/custom_components/chore_calendar/__init__.py
+++ b/custom_components/chore_calendar/__init__.py
@@ -27,7 +27,6 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 CARD_JS = "chore-calendar-card.js"
 CARD_URL_PATH = f"/{DOMAIN}/{CARD_JS}"
-_RESOURCE_TRACKER = f"{DOMAIN}_lovelace_resource_id"
 
 
 class ChoreCalendarData(NamedTuple):
@@ -109,7 +108,6 @@ async def _async_register_card_resource(hass: HomeAssistant, resource_url: str) 
         return
 
     data = await resources.async_create_item({CONF_RESOURCE_TYPE_WS: "module", CONF_URL: resource_url})
-    hass.data[_RESOURCE_TRACKER] = data[CONF_ID]
     _LOGGER.debug("Registered card as Lovelace resource (ID %s)", data[CONF_ID])
 
 

--- a/custom_components/chore_calendar/actions.py
+++ b/custom_components/chore_calendar/actions.py
@@ -2,10 +2,9 @@
 
 These are the building blocks the ``services.py`` handlers, the ``todo``
 platform, and the tag-scan listener all reuse — completion, uncompletion,
-the per-list completed-items sweep, and the calendar-listener invalidation
-hook. Keeping them in their own module breaks an awkward
-``platforms → services`` dependency edge and lets ``services.py`` focus on
-service-handler glue.
+and the per-list completed-items sweep. Keeping them in their own module
+breaks an awkward ``platforms → services`` dependency edge and lets
+``services.py`` focus on service-handler glue.
 """
 
 from __future__ import annotations
@@ -18,7 +17,7 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN, EVENT_ITEM_DELETED, LOGGER, ChoreStatus
+from .const import EVENT_ITEM_DELETED, LOGGER, ChoreStatus
 from .models import OneshotChore
 
 if TYPE_CHECKING:
@@ -50,7 +49,6 @@ async def async_complete_chore(
     existing.apply_completion(timestamp, completed_by, clear_skip=not keep_skip)
     await store.async_update_chore(existing)
     await coordinator.async_refresh()
-    notify_calendar_event_listeners(coordinator.hass, store.entry_id)
     LOGGER.info("completed %s (%s) at %s", existing.chore_name, uid, timestamp.isoformat())
 
 
@@ -78,7 +76,6 @@ async def async_uncomplete_chore(
     coordinator.mark_uncompleted(uid)
     await store.async_update_chore(existing)
     await coordinator.async_refresh()
-    notify_calendar_event_listeners(coordinator.hass, store.entry_id)
     LOGGER.info("uncompleted %s (%s)", existing.chore_name, uid)
 
 
@@ -137,42 +134,6 @@ async def async_apply_completed_cleared_at(
 
     LOGGER.debug("persist=false sweep complete: %d chore(s) deleted", swept)
     await coordinator.async_refresh()
-    notify_calendar_event_listeners(hass, store.entry_id)
-
-
-def notify_calendar_event_listeners(hass: HomeAssistant, entry_id: str) -> None:
-    """Push fresh events to the calendar panel subscribers for *entry_id*.
-
-    HA's calendar dashboard caches event lists client-side and does not
-    refetch on ``state_changed`` — CRUD actions on chores leave stale
-    events visible until the user navigates dates or reloads the browser.
-    ``CalendarEntity.async_update_event_listeners`` (added on HA dev,
-    post-2026.3.1) lets the integration push an invalidation.
-
-    Looks up the calendar entity for the given config entry (its unique_id
-    is the entry_id) and calls the listener-update method when present.
-    Silently no-ops when:
-
-    - The calendar entity isn't loaded for this entry.
-    - The HA version doesn't yet implement ``async_update_event_listeners``.
-    """
-    registry = er.async_get(hass)
-    calendar_entity_id = registry.async_get_entity_id("calendar", DOMAIN, entry_id)
-    if calendar_entity_id is None:
-        return
-
-    calendar_component = hass.data.get("calendar")
-    if calendar_component is None:
-        return
-    entity = calendar_component.get_entity(calendar_entity_id)
-    notify = getattr(entity, "async_update_event_listeners", None)
-    if notify is None:
-        return
-    notify()
-    LOGGER.debug(
-        "Pushed calendar event update to subscribers of %s",
-        calendar_entity_id,
-    )
 
 
 def resolve_tag_entity_id(hass: HomeAssistant, trigger_tag_id: str | None) -> str | None:

--- a/custom_components/chore_calendar/coordinator.py
+++ b/custom_components/chore_calendar/coordinator.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 from datetime import timedelta
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
-from .const import DEFAULT_UPDATE_INTERVAL, EVENT_STATUS_CHANGED, LOGGER, ChoreStatus
+from .const import DEFAULT_UPDATE_INTERVAL, DOMAIN, EVENT_STATUS_CHANGED, LOGGER, ChoreStatus
 from .models import BaseChore
 from .store import ChoreStore
 
@@ -36,7 +37,15 @@ class ChoreCalendarCoordinator(DataUpdateCoordinator[dict[str, BaseChore]]):
         self._pending_uncomplete_uids.add(uid)
 
     async def _async_update_data(self) -> dict[str, BaseChore]:
-        """Evaluate all chore statuses and fire events on transitions."""
+        """Evaluate all chore statuses, fire events on transitions, and push the calendar listener invalidation.
+
+        ``_notify_event_listeners`` covers every refresh path uniformly —
+        service-driven CRUD (which calls ``coordinator.async_refresh()``) as
+        well as the periodic tick. The notifier is a no-op when the calendar
+        entity isn't loaded or when the underlying
+        ``CalendarEntity.async_update_event_listeners`` API isn't available,
+        so the unconditional call is cheap.
+        """
         chores = self.store.get_all_chores()
         now = dt_util.now()
 
@@ -67,4 +76,37 @@ class ChoreCalendarCoordinator(DataUpdateCoordinator[dict[str, BaseChore]]):
         for uid in deleted:
             del self._previous_statuses[uid]
 
+        self._notify_event_listeners()
         return chores
+
+    def _notify_event_listeners(self) -> None:
+        """Push fresh events to the calendar panel subscribers for this list.
+
+        HA's calendar dashboard caches event lists client-side and does not
+        refetch on ``state_changed`` — refreshes on chores leave stale events
+        visible until the user navigates dates or reloads the browser.
+        ``CalendarEntity.async_update_event_listeners`` (added on HA dev,
+        post-2026.3.1) lets the integration push an invalidation.
+
+        Silently no-ops when:
+
+        - The calendar entity isn't loaded for this entry.
+        - The HA version doesn't yet implement ``async_update_event_listeners``.
+        """
+        registry = er.async_get(self.hass)
+        calendar_entity_id = registry.async_get_entity_id("calendar", DOMAIN, self.store.entry_id)
+        if calendar_entity_id is None:
+            return
+
+        calendar_component = self.hass.data.get("calendar")
+        if calendar_component is None:
+            return
+        entity = calendar_component.get_entity(calendar_entity_id)
+        notify = getattr(entity, "async_update_event_listeners", None)
+        if notify is None:
+            return
+        notify()
+        LOGGER.debug(
+            "Pushed calendar event update to subscribers of %s",
+            calendar_entity_id,
+        )

--- a/custom_components/chore_calendar/services.py
+++ b/custom_components/chore_calendar/services.py
@@ -17,7 +17,6 @@ from .actions import (
     async_apply_completed_cleared_at,
     async_complete_chore,
     async_uncomplete_chore,
-    notify_calendar_event_listeners,
     resolve_tag_entity_id,
 )
 from .const import (
@@ -337,7 +336,6 @@ async def _async_handle_create(call: ServiceCall) -> None:
 
     await store.async_create_chore(chore)
     await coordinator.async_refresh()
-    notify_calendar_event_listeners(call.hass, store.entry_id)
     LOGGER.info("created %s (%s)", chore.chore_name, uid)
 
 
@@ -401,7 +399,6 @@ async def _async_handle_update(call: ServiceCall) -> None:
     chore = BaseChore.from_dict(updated)
     await store.async_update_chore(chore)
     await coordinator.async_refresh()
-    notify_calendar_event_listeners(call.hass, store.entry_id)
     LOGGER.info("updated %s (%s)", existing.chore_name, uid)
 
 
@@ -417,7 +414,6 @@ async def _async_handle_delete(call: ServiceCall) -> None:
 
     await store.async_delete_chore(uid)
     await coordinator.async_refresh()
-    notify_calendar_event_listeners(call.hass, store.entry_id)
 
     call.hass.bus.async_fire(
         EVENT_ITEM_DELETED,
@@ -487,7 +483,6 @@ async def _async_handle_skip(call: ServiceCall) -> None:
 
     await store.async_update_chore(existing)
     await coordinator.async_refresh()
-    notify_calendar_event_listeners(call.hass, store.entry_id)
 
     call.hass.bus.async_fire(
         EVENT_ITEM_SKIPPED,

--- a/custom_components/chore_calendar/services.py
+++ b/custom_components/chore_calendar/services.py
@@ -328,7 +328,10 @@ async def _async_handle_create(call: ServiceCall) -> None:
     chore.created_at = dt_util.now()
 
     # Seed last_completed from the tag's last-scanned time so existing tag
-    # systems transfer state into chore calendar on creation.
+    # systems transfer state into chore calendar on creation. Side effect:
+    # the chore's initial status reflects the seeded last_completed (typically
+    # `completed`) rather than the standard never-completed `pending`. That's
+    # intentional for the migration use case but worth flagging — see README.
     last_scanned = _resolve_tag_last_scanned(call.hass, call.data.get(ATTR_TRIGGER_ENTITY))
     if last_scanned is not None:
         chore.last_completed = last_scanned


### PR DESCRIPTION
# Summary

- **Drop `_RESOURCE_TRACKER` dead code.** The constant on `hass.data` was set when registering the Lovelace card resource but never read — reserved for an unload-time deregistration path that doesn't exist. Removed, leaving the rest of `_async_register_card_resource` (the race-condition fix for `add_extra_js_url`) intact.
- **Bind calendar listener notifier to the coordinator update lifecycle.** `notify_calendar_event_listeners` was called explicitly from seven sites (four service handlers, three action helpers) right after each `coordinator.async_refresh()`. Moved into the coordinator as a private method so every refresh path — service-driven CRUD as well as the periodic 60s tick — pushes the invalidation uniformly. The function still silently no-ops when `CalendarEntity.async_update_event_listeners` isn't available, so the unconditional periodic call is cheap.
- **Clarify tag-seed initial-status side effect in docs.** The `last_completed` seeding rule on `create_item` (a deliberate migration aid for users coming from tag-based systems) leaves a freshly-created chore in a status that reflects the seeded `last_completed` rather than the documented never-completed `pending`. One sentence added to the in-code comment and the user-facing README paragraph so the side effect is discoverable.

# Test plan

- [x] Trigger any CRUD action (`create_item`, `update_item`, `delete_item`, `complete_item`, `uncomplete_item`, `skip_item`, `hide_completed_items`); verify the calendar dashboard still refreshes correctly — the underlying API is gated by HA version, so on stable releases this is a no-op confirmation.
- [x] Create a chore with a recently-scanned `tag.*` trigger; verify it lands in `completed` (or the cycle position the seeded `last_completed` puts it at) rather than `pending`, matching the new README sentence.
