### PR TITLE
feat: render placeholder row when no chores are visible

### DIFF
--- a/card/src/chore-calendar-card.ts
+++ b/card/src/chore-calendar-card.ts
@@ -273,6 +273,27 @@ export class ChoreCalendarCard extends LitElement {
       font-size: 14px;
     }
 
+    .placeholder {
+      margin-bottom: 5px;
+    }
+
+    .placeholder-card {
+      background: var(--card-background-color, var(--ha-card-background, white));
+      border-radius: 0 5px 5px 0;
+      border-left: 5px solid var(--divider-color, rgba(0, 0, 0, 0.12));
+      overflow: hidden;
+    }
+
+    .placeholder-row {
+      display: flex;
+      align-items: center;
+      padding: 10px;
+      gap: 12px;
+      font-size: 14px;
+      color: var(--secondary-text-color);
+      font-style: italic;
+    }
+
     .loading {
       padding: 32px 0;
       text-align: center;
@@ -324,20 +345,30 @@ export class ChoreCalendarCard extends LitElement {
   }
 
   private _renderSections() {
-    if (this._items.length === 0) {
-      return html`<div class="empty">No chores to show</div>`;
-    }
-
     const groups = groupByStatus(this._items);
     const hideCompleted = !!this._config.hide_completed;
     const hideSections = !!this._config.hide_section_headers;
 
-    return html`
-      ${SECTION_ORDER.map((status) => {
-        const items = groups.get(status);
-        if (!items || items.length === 0) return nothing;
-        if (status === "completed" && hideCompleted) return nothing;
+    const visibleSections = SECTION_ORDER.filter((status) => {
+      const items = groups.get(status);
+      if (!items || items.length === 0) return false;
+      if (status === "completed" && hideCompleted) return false;
+      return true;
+    });
 
+    if (visibleSections.length === 0) {
+      return html`
+        <div class="placeholder">
+          <div class="placeholder-card">
+            <div class="placeholder-row">No chores</div>
+          </div>
+        </div>
+      `;
+    }
+
+    return html`
+      ${visibleSections.map((status) => {
+        const items = groups.get(status)!;
         return html`
           ${!hideSections
             ? html`<div class="section-header ${status}">

--- a/custom_components/chore_calendar/www/chore-calendar-card.js
+++ b/custom_components/chore_calendar/www/chore-calendar-card.js
@@ -457,12 +457,18 @@ function t(t,e,i,o){var s,n=arguments.length,a=n<3?e:null===o?o=Object.getOwnPro
         @chore-uncompleted=${this._onChoreCompleted}
         @chore-skipped=${this._onChoreCompleted}
       ></chore-detail-dialog>
-    `}_renderSections(){if(0===this._items.length)return W`<div class="empty">No chores to show</div>`;const t=function(t){const e=new Map;for(const i of t){let t=e.get(i.status);t||(t=[],e.set(i.status,t)),t.push(i)}return e}(this._items),e=!!this._config.hide_completed,i=!!this._config.hide_section_headers;return W`
-      ${Ft.map(o=>{const s=t.get(o);return s&&0!==s.length?"completed"===o&&e?F:W`
-          ${i?F:W`<div class="section-header ${o}">
-                ${Et[o]}
+    `}_renderSections(){const t=function(t){const e=new Map;for(const i of t){let t=e.get(i.status);t||(t=[],e.set(i.status,t)),t.push(i)}return e}(this._items),e=!!this._config.hide_completed,i=!!this._config.hide_section_headers,o=Ft.filter(i=>{const o=t.get(i);return!(!o||0===o.length)&&("completed"!==i||!e)});return 0===o.length?W`
+        <div class="placeholder">
+          <div class="placeholder-card">
+            <div class="placeholder-row">No chores</div>
+          </div>
+        </div>
+      `:W`
+      ${o.map(e=>{const o=t.get(e);return W`
+          ${i?F:W`<div class="section-header ${e}">
+                ${Et[e]}
               </div>`}
-          ${s.map(t=>W`
+          ${o.map(t=>W`
               <chore-row
                 .hass=${this.hass}
                 .item=${t}
@@ -471,7 +477,7 @@ function t(t,e,i,o){var s,n=arguments.length,a=n<3?e:null===o?o=Object.getOwnPro
                 .doubleTapAction=${this._config.double_tap_action??{action:"none"}}
               ></chore-row>
             `)}
-        `:F})}
+        `})}
     `}_onChoreDetail(t){this._dialogItem=t.detail.item,this._dialogOpen=!0}_onDialogClosed(){this._dialogOpen=!1}_onChoreCompleted(){this._dialogOpen=!1,this._refreshData()}}Vt.styles=a`
     :host {
       display: block;
@@ -531,6 +537,27 @@ function t(t,e,i,o){var s,n=arguments.length,a=n<3?e:null===o?o=Object.getOwnPro
       text-align: center;
       color: var(--secondary-text-color);
       font-size: 14px;
+    }
+
+    .placeholder {
+      margin-bottom: 5px;
+    }
+
+    .placeholder-card {
+      background: var(--card-background-color, var(--ha-card-background, white));
+      border-radius: 0 5px 5px 0;
+      border-left: 5px solid var(--divider-color, rgba(0, 0, 0, 0.12));
+      overflow: hidden;
+    }
+
+    .placeholder-row {
+      display: flex;
+      align-items: center;
+      padding: 10px;
+      gap: 12px;
+      font-size: 14px;
+      color: var(--secondary-text-color);
+      font-style: italic;
     }
 
     .loading {


### PR DESCRIPTION
Previously the card showed a plain centered "No chores to show" message only when zero items were fetched. If items existed but were all hidden by filters (excluded statuses, period filters, hide_completed), the card rendered empty.

Now the empty check runs after section filtering and renders a chore-row-shaped placeholder ("No chores") so the layout stays consistent.