### PR TITLE
ci: auto-build the card bundle instead of verifying it

### DIFF
--- a/.github/actions/build-card/action.yml
+++ b/.github/actions/build-card/action.yml
@@ -1,0 +1,39 @@
+name: Build card
+description: >-
+  Build the Lovelace card bundle, then either commit the result (if it drifted
+  from the committed bundle) or verify the committed bundle is already current.
+
+inputs:
+  commit:
+    description: >-
+      "true" commits the rebuilt bundle back to the current branch if it
+      changed; "false" fails the job when the committed bundle is stale
+      (verify-only). The caller must have checked out a writable branch when
+      committing.
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Node
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version: "20"
+        cache: "npm"
+        cache-dependency-path: "card/package-lock.json"
+
+    - name: Build card
+      shell: bash
+      run: script/card/build
+
+    - name: Commit refreshed bundle
+      if: ${{ inputs.commit == 'true' }}
+      uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+      with:
+        commit_message: "build: rebuild card bundle"
+        file_pattern: "custom_components/chore_calendar/www/*"
+
+    - name: Verify committed bundle matches build
+      if: ${{ inputs.commit != 'true' }}
+      shell: bash
+      run: git diff --exit-code -- custom_components/chore_calendar/www/

--- a/.github/actions/build-card/action.yml
+++ b/.github/actions/build-card/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Set up Node
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "20"
         cache: "npm"

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,23 +1,24 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "9e083046b2dcc68e0f198fb6f2e4c70035299d77",
+  "pull-request-title-pattern": "chore: release v${version}",
   "packages": {
     ".": {
       "release-type": "simple",
       "package-name": "chore_calendar",
       "include-v-in-tag": true,
       "changelog-sections": [
-        { "type": "feat",     "section": "Features" },
-        { "type": "fix",      "section": "Bug Fixes" },
-        { "type": "perf",     "section": "Performance Improvements" },
-        { "type": "revert",   "section": "Reverts" },
-        { "type": "refactor", "section": "Code Refactoring",        "hidden": false },
-        { "type": "docs",     "section": "Documentation",           "hidden": false },
-        { "type": "build",    "section": "Build System",            "hidden": true },
-        { "type": "ci",       "section": "Continuous Integration",  "hidden": true },
-        { "type": "test",     "section": "Tests",                   "hidden": true },
-        { "type": "chore",    "section": "Miscellaneous Chores",    "hidden": true },
-        { "type": "style",    "section": "Styles",                  "hidden": true }
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "refactor", "section": "Code Refactoring", "hidden": false },
+        { "type": "docs", "section": "Documentation", "hidden": false },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true }
       ],
       "extra-files": [
         {

--- a/.github/workflows/card.yml
+++ b/.github/workflows/card.yml
@@ -8,7 +8,8 @@ on:
     branches:
       - "main"
 
-permissions: {}
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -16,16 +17,15 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "20"
-          cache: "npm"
-          cache-dependency-path: "card/package-lock.json"
+          # On pull requests, check out the head branch (not the detached merge
+          # ref) so a rebuilt bundle can be committed back to it. Empty on push
+          # events, where checkout falls back to the pushed ref.
+          ref: ${{ github.head_ref }}
 
+      # On pull requests, rebuild and commit the bundle if it drifted from
+      # source (no more "forgot to rebuild" CI failures). On main, verify only.
       - name: Build card
-        run: script/card/build
-
-      - name: Verify committed bundle matches build
-        run: git diff --exit-code -- custom_components/chore_calendar/www/
+        uses: ./.github/actions/build-card
+        with:
+          commit: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,24 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Run release-please
+        id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+
+      # release-please bumps manifest.json but cannot rebuild the card, whose
+      # bundle bakes in the manifest version at build time. Rebuild and commit
+      # it on the release PR branch so the merged release ships a bundle whose
+      # banner matches the released version. The GITHUB_TOKEN push does not
+      # re-trigger PR checks (by design), which is fine — the bundle is correct
+      # by merge time.
+      - name: Check out release PR branch
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+
+      - name: Rebuild card for release
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        uses: ./.github/actions/build-card


### PR DESCRIPTION
Extracts the card build into a reusable composite action (.github/actions/build-card) that either commits a refreshed bundle or verifies the committed one, via a "commit" input.

- card.yml: on pull requests, rebuild and commit the bundle when it drifts from source (no more "forgot to rebuild" failures); on main, verify only.
- release-please.yml: rebuild + commit the card on the release PR branch in the same run, so the merged release ships a bundle whose banner matches the bumped manifest version.