### PR TITLE
fix: follow-up default skip during pending advances by one occurrence

### DIFF
--- a/custom_components/chore_calendar/models/scheduled.py
+++ b/custom_components/chore_calendar/models/scheduled.py
@@ -59,12 +59,26 @@ class ScheduledChore(BaseChore):
     def apply_default_skip(self, now: datetime) -> datetime | None:
         """Skip to the next active day's period-due strictly after *now*.
 
-        Walks forward from the current operative period. An overdue chore's
-        period may be pinned in the past — stepping once would still land
-        in the past, so we advance until the candidate is strictly after
-        *now*. Guarantees the skip actually takes effect.
+        Walks forward from the **operative** anchor — ``skipped_until`` when
+        an active skip overrides the natural anchor, otherwise the current
+        period_due. Starting from the operative anchor is what makes a
+        follow-up default skip advance by one occurrence: without it, a skip
+        performed inside the skip-anchor's pending window would walk from the
+        natural (pre-skip) period, hit the existing ``skipped_until``, and
+        produce a no-op.
+
+        An overdue chore's anchor may still be pinned in the past — stepping
+        once would land in the past, so we advance until the candidate is
+        strictly after *now*.
         """
-        candidate = self._find_next_active_day(self._find_current_period(now))
+        # Operative anchor is non-None for ScheduledChore — _anchor_due_at
+        # always resolves a period — but the base signature returns
+        # ``datetime | None``, so resolve directly here.
+        if self._skip_anchor_active(now) and self.skipped_until is not None:
+            anchor = self.skipped_until
+        else:
+            anchor = self._find_current_period(now)
+        candidate = self._find_next_active_day(anchor)
         while candidate <= now:
             candidate = self._find_next_active_day(candidate)
         self.skipped_until = candidate

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -576,6 +576,31 @@ class TestScheduledChoreSkip:
         assert result == expected
         assert chore.skipped_until == expected
 
+    def test_apply_default_skip_advances_existing_skip_in_pending(self):
+        """A follow-up default skip during the skip-anchor's pending window advances by one occurrence.
+
+        Regression: previously the walk started from the *natural* period
+        (anchored on ``last_completed``), so a chore in the skip-anchor's
+        pending window walked to the same active day the existing
+        ``skipped_until`` already pointed at — a no-op. Starting the walk
+        from the operative anchor (``skipped_until`` when active) advances
+        by one full active-day step instead.
+        """
+        chore = _make_scheduled(
+            last_completed=datetime(2026, 3, 30, 8, 0, tzinfo=TZ),  # Mon
+            # First skip already pushed next due to Wed 08:00.
+        )
+        chore.skipped_until = datetime(2026, 4, 1, 8, 0, tzinfo=TZ)
+        # Wed 06:00 — inside the skip anchor's pending window (05:00–08:00).
+        now = datetime(2026, 4, 1, 6, 0, tzinfo=TZ)
+        assert chore.compute_status(now) == ChoreStatus.PENDING
+
+        result = chore.apply_default_skip(now)
+        expected = datetime(2026, 4, 2, 8, 0, tzinfo=TZ)
+        assert result == expected
+        assert chore.skipped_until == expected
+        assert chore.compute_status(now) == ChoreStatus.COMPLETED
+
     def test_skip_from_overdue_transitions_to_completed(self):
         """Calling skip on an OVERDUE chore flips status to COMPLETED via skipped_until."""
         chore = _make_scheduled(


### PR DESCRIPTION
A second `skip_item` (no `until` arg) on a scheduled chore inside the skip-anchor's pending window was a no-op — `skipped_until` came out unchanged and the status stayed PENDING.

`apply_default_skip` walked from `_find_current_period(now)`, which is the natural anchor (anchored on `last_completed`). With `last_completed` in a prior period and the first skip already pointing at the next active day, the walk produced the same target as the existing `skipped_until`. The `while candidate <= now` guard only protects against landing in the past, not against landing on the prior skip.

Walk from the operative anchor instead — `skipped_until` when an active skip overrides the natural anchor, else the current period_due. A follow-up skip now lands one active day past the existing one and the PENDING → COMPLETED transition fires.

Interval is unaffected (`now + interval` already lands past any skip in the immediate prior pending window). Oneshot's default-skip semantics (clear `due_datetime`) are intentionally unchanged.