### PR TITLE
fix: migrate card editor period inputs from ha-textfield to ha-input

### DIFF
--- a/card/src/chore-calendar-card-editor.ts
+++ b/card/src/chore-calendar-card-editor.ts
@@ -240,7 +240,7 @@ export class ChoreCalendarCardEditor extends LitElement {
       flex-shrink: 0;
     }
 
-    .period-inputs ha-textfield {
+    .period-inputs ha-input {
       width: 88px;
     }
   `;
@@ -479,7 +479,7 @@ export class ChoreCalendarCardEditor extends LitElement {
   private _renderPeriodRow(key: "due_date_period" | "completed_period", label: string) {
     const current = this._config[key] ?? {};
     // If either unit is set, show both (the missing one as "0"). If neither is
-    // set, both fields stay blank so the Material floating labels are visible.
+    // set, both fields stay blank so the placeholders are visible.
     const anySet = !!(current.days || current.hours);
     const daysValue = anySet ? String(current.days ?? 0) : "";
     const hoursValue = anySet ? String(current.hours ?? 0) : "";
@@ -487,24 +487,26 @@ export class ChoreCalendarCardEditor extends LitElement {
       <div class="period-row">
         <span class="period-label">${label}</span>
         <div class="period-inputs">
-          <ha-textfield
+          <ha-input
+            appearance="outlined"
             type="number"
             min="0"
             max="365"
-            label="days"
+            placeholder="days"
             .value=${daysValue}
             @change=${(ev: Event) =>
               this._setPeriod(key, "days", (ev.target as HTMLInputElement).value)}
-          ></ha-textfield>
-          <ha-textfield
+          ></ha-input>
+          <ha-input
+            appearance="outlined"
             type="number"
             min="0"
             max="23"
-            label="hours"
+            placeholder="hours"
             .value=${hoursValue}
             @change=${(ev: Event) =>
               this._setPeriod(key, "hours", (ev.target as HTMLInputElement).value)}
-          ></ha-textfield>
+          ></ha-input>
         </div>
       </div>
     `;

--- a/custom_components/chore_calendar/www/chore-calendar-card.js
+++ b/custom_components/chore_calendar/www/chore-calendar-card.js
@@ -293,22 +293,24 @@ function t(t,e,i,o){var s,n=arguments.length,a=n<3?e:null===o?o=Object.getOwnPro
       <div class="period-row">
         <span class="period-label">${e}</span>
         <div class="period-inputs">
-          <ha-textfield
+          <ha-input
+            appearance="outlined"
             type="number"
             min="0"
             max="365"
-            label="days"
+            placeholder="days"
             .value=${s}
             @change=${e=>this._setPeriod(t,"days",e.target.value)}
-          ></ha-textfield>
-          <ha-textfield
+          ></ha-input>
+          <ha-input
+            appearance="outlined"
             type="number"
             min="0"
             max="23"
-            label="hours"
+            placeholder="hours"
             .value=${n}
             @change=${e=>this._setPeriod(t,"hours",e.target.value)}
-          ></ha-textfield>
+          ></ha-input>
         </div>
       </div>
     `}_setPeriod(t,e,i){if(!this._config)return;const o=Math.max(0,Math.floor(Number(i)||0)),s={...this._config[t]??{},[e]:o};s.days||delete s.days,s.hours||delete s.hours;const n=Object.keys(s).length>0;this._config={...this._config,[t]:n?s:void 0},this._dispatch()}_optionsChanged(t){t.stopPropagation(),this._config&&this.hass&&(this._config={...this._config,...t.detail.value},this._dispatch())}}qt.styles=a`
@@ -428,7 +430,7 @@ function t(t,e,i,o){var s,n=arguments.length,a=n<3?e:null===o?o=Object.getOwnPro
       flex-shrink: 0;
     }
 
-    .period-inputs ha-textfield {
+    .period-inputs ha-input {
       width: 88px;
     }
   `,t([ht({attribute:!1})],qt.prototype,"hass",void 0),t([pt()],qt.prototype,"_config",void 0),t([pt()],qt.prototype,"_expandedEntities",void 0),ut("chore-calendar-card-editor",qt);console.info("%c CHORE-CALENDAR-CARD %c v0.10.0 ","color: white; background: #4CAF50; font-weight: 700;","color: #4CAF50; background: white; font-weight: 700;");const Ft=["overdue","due","pending","completed"];class Vt extends rt{constructor(){super(...arguments),this._items=[],this._loading=!0,this._dialogOpen=!1,this._entityConfigs=[],this._connected=!1}static getConfigElement(){return document.createElement("chore-calendar-card-editor")}static getStubConfig(){return{entities:[]}}setConfig(t){if(!t.entities||0===t.entities.length)return this._configError="Please define at least one entity",void(this._config=t);this._configError=void 0,this._config=t,this._entityConfigs=t.entities.map((t,e)=>function(t,e){const i="string"==typeof t?{entity:t}:t;return{...i,color:i.color??_t[e%_t.length]}}(t,e)),t.hide_card_background?this.setAttribute("no-card-background",""):this.removeAttribute("no-card-background")}getCardSize(){return Math.max(3,this._items.length+1)}connectedCallback(){super.connectedCallback(),this._connected=!0,this._startPolling(),this._subscribeEvents()}disconnectedCallback(){super.disconnectedCallback(),this._connected=!1,this._stopPolling(),this._unsubscribeEvents()}updated(t){t.has("hass")&&this.hass&&this._loading&&this._refreshData()}async _refreshData(){var t;if(this.hass&&this._config)try{const e=[],i=this._entityConfigs.map(async t=>{const i=await this.hass.callWS({type:"call_service",domain:"chore_calendar",service:"get_items",service_data:{entity_id:t.entity},return_response:!0}),o=i.response?.items??[],s=i.response?.completed_cleared_at?new Date(i.response.completed_cleared_at).getTime():null,n=t.exclude??[];for(const i of o)n.includes(i.status)||null!==s&&"completed"===i.status&&i.last_completed&&new Date(i.last_completed).getTime()<s||e.push({...i,source_entity:t.entity,source_color:t.color})});await Promise.all(i);const o=xt(this._config.due_date_period),s=xt(this._config.completed_period),n=function(t,e,i,o){if(null===e&&null===i)return t;const s=o.getTime();return t.filter(t=>{if(null!==i&&"completed"===t.status&&t.last_completed&&s-new Date(t.last_completed).getTime()>i)return!1;if(null!==e&&"pending"===t.status){if(!t.next_due)return!1;if(new Date(t.next_due).getTime()-s>e)return!1}return!0})}(e,o,s,new Date);this._items=(t=n,[...t].sort((t,e)=>{const i=vt[t.status]-vt[e.status];if(0!==i)return i;if("completed"===t.status){const i=t.last_completed?new Date(t.last_completed).getTime():0;return(e.last_completed?new Date(e.last_completed).getTime():0)-i}return(t.next_due?new Date(t.next_due).getTime():1/0)-(e.next_due?new Date(e.next_due).getTime():1/0)}))}catch(t){console.error("chore-calendar-card: failed to fetch items",t)}finally{this._loading=!1}}_startPolling(){this._stopPolling();const t=1e3*(this._config?.update_interval??60);this._refreshTimer=setInterval(()=>{this._connected&&this._refreshData()},t)}_stopPolling(){void 0!==this._refreshTimer&&(clearInterval(this._refreshTimer),this._refreshTimer=void 0)}async _subscribeEvents(){if(this.hass?.connection)try{const t=new Set(this._entityConfigs.map(t=>t.entity));this._eventUnsub=await this.hass.connection.subscribeEvents(e=>{e.data?.entity_id&&t.has(e.data.entity_id)&&this._refreshData()},"state_changed")}catch{}}_unsubscribeEvents(){this._eventUnsub?.(),this._eventUnsub=void 0}render(){if(!this._config)return F;if(this._configError)return W`

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Chore Calendar",
-  "homeassistant": "2026.3.1",
+  "homeassistant": "2026.4.0",
   "hacs": "2.0.5"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -16,4 +16,4 @@
 
 # Testing utilities for Home Assistant custom components
 # Provides additional fixtures and utilities specifically for custom component testing
-pytest-homeassistant-custom-component==0.13.317
+pytest-homeassistant-custom-component==0.13.322


### PR DESCRIPTION
HA 2026.5 removed the ha-textfield custom element (added in 2026.4). The custom period rows in the card editor still used it and failed to render.

Bump min version to 2026.4.0